### PR TITLE
WIP: update methods 2025

### DIFF
--- a/content/01.abstract.md
+++ b/content/01.abstract.md
@@ -1,10 +1,11 @@
 ## Abstract {.page_break_before}
 
 We introduce branchwater, a flexible and fast petabase-scale search
-for the 767,000 public metagenomes presently in the NCBI Sequence Read
-Archive. Our search is based on the FracMinHash k-mer sketching
-technique and can search all public metagenomes with 1000 query
-genomes in approximately 36 hours using 50 GB of RAM and 32 threads.
-Branchwater is a Rust-based multithreading front-end built on top of
-the sourmash library. We provide biological use cases, examine
-performance, and discuss design and performance considerations.
+for the over 1 million public metagenomes presently in the NCBI Sequence
+Read Archive. This search is based on the FracMinHash k-mer sketching
+technique and can search all public metagenomes with a query
+genome in seconds with a single thread using an on-disk index.
+For additional search flexibility, branchwater also provides a Rust-based
+multithreading front-end built on top of the sourmash library.
+We provide biological use cases, examine performance, and discuss
+design and performance considerations.

--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -8,57 +8,18 @@
  the minimal system requirements needed to run the software and an
  overview of the workflow.* -->
 
-### Sketching the Sequence Read Archive
-
-We determined the accessions of all publicly available shotgun
-metagenomic via the query string `"METAGENOMIC"[Source] NOT
-amplicon[All Fields]` at the NCBI Sequence Read Archive Web site,
-https://www.ncbi.nlm.nih.gov/sra.  We then downloaded all runs for all
-accessions and streamed them into `sourmash sketch dna` with
-parameters `-p k=21,31,51,scaled=1000,abund`. The output sourmash
-signature files were saved as individual gzipped JSON files - 
-one file for each input data set, each containing 3 sketches.
-
-The resulting catalog contains 767,277 metagenome data sets as of
-March 2022, with the largest category annotated as human-associated microbiomes
-(Table @tbl:sra-types). The size of all sketches together is 7.5 TB,
-containing approximately 375 billion hashes per k-mer size and
-representing 375 trillion k-mers <!-- from ZZZ PB of original files CTB -->.
-There are 2.20 billion distinct hashes in this collection, representing
-approximately 2.20 trillion distinct k-mers.
-
-The
-average sketch file size is 9.7 MB, and the median file size is 570kb. The
-largest 10,000 data sets comprise 30% of the total catalog size.
-
-<!-- NTP question: how big is largest sketch? XXX -->
-
-| "Scientific Name" provided by submitter | distinct data sets |
-| --- | --- |
-| human gut metagenome  |   162187 |
-| metagenome              |   57048
-| gut metagenome           | 47244
-| human metagenome         | 36438
-| soil metagenome          | 35323
-| mouse gut metagenome     | 26482
-| human skin metagenome    | 25700
-| Homo sapiens             | 21020
-| marine metagenome        |14400
-| human oral metagenome    |  14235
-
-Table: The 10 largest categories of metagenome data set types in the Sequence
-Read Archive, as of March 2022. {#tbl:sra-types}
-
 ### Implementation of multithreaded search
 
 <!-- CTB: rename program to branchwater? -->
+
+<!-- NTP: modify to better describe all options for multithreaded search? -->
 
 The branchwater program is built in Rust on top of the sourmash
 library for loading and comparing sketches. It implements the
 following steps: <!-- CTB figure? -->
 
-1. Loads all query sketches into memory from a list of files.
-2. Loads the list of filenames containing subject sketches to search.
+1. Loads the collection of query sketches into memory.
+2. Loads references to the collection of subject sketches to search.
 3. In a Rust closure function executed in parallel for each subject sketch filename,
    a. loads the subject sketch from the file;
    b. for each query, determines the estimated overlap between query and subject;
@@ -77,14 +38,82 @@ storing them all in memory. The approach also takes advantage of the
 effective immutability of queries, which can be shared without
 data races by multiple processing threads.
 
+### Implementation of an on-disk index
+
+branchwater implements a new index using RocksDB, a high-performance embedded key-value store. This 'inverted' index maps hashed k-mers to the sketches in which they are found. Each ‘key’ in the index is a hashed k-mer stored using little-endian encoding, while each ‘value’ is the list of dataset identifiers that contain this k-mer. This list is stored as a roaring bitmap to enable fast set operations and random access into the list. The index also stores additional metadata per dataset. In particular, this metadata can provide linkages to the FracMinHash sketches from each dataset so they can be loaded for detailed comparison and reporting if needed.
+
+**Index Construction** The index is constructed by iterating through batches of FracMinHash sketches in parallel and storing each hashed k-mer with its associated dataset ID. If a k-mer occurs in multiple sketches, the corresponding dataset list is updated to include all associated dataset IDs. Values are stored in a compact binary format to reduce storage overhead and improve retrieval speed. Progress is tracked to ensure proper construction and facilitate restart and continuation of the indexing process. After construction of an initial index, updating with new sketches can be done incrementally.
+
+**Parameters and Scaling** RocksDB indexes are constructed for individual k-mer sizes and scaled values. If the query was constructed at higher FracMinHash resolution, it can be downsampled to match the database. For simple searches, the FracMinHash sketches used to construct the index are not required, and only the dataset IDs are needed. This allows for minimal storage overhead. However, for more detailed comparisons, including min-set-cov applications, the full FracMinHash sketches can be stored within the index or linked externally. This flexibility allows users to choose the level of detail and storage requirements based on their specific use case.
+
+**Querying the Index** To query the index, branchwater performs batch lookups of the hashed query k-mers in the RocksDB index to retrieve the datasets associated with each hash. These results are then aggregated to determine the number of hashed k-mers found per candidate dataset, i.e. the intersection of k-mers found in the query and each dataset. We can then use the query sketch information to estimate the containment of the query in each dataset (intersection_size/query_size). This approach enables sublinear search time with respect to the total number of k-mers in the database, supporting efficient large-scale sequence comparisons and search across petabyte-scale collections. Other reporting is feasible, but requires loading the FracMinHash sketch associated with each dataset.
+
 ### Executing branchwater at the command line
 
-branchwater takes in search parameters as well as two text files, one
-containing a list of query file paths and one containing a list of
-subject file paths. Upon execution, it reports the number of query
-sketches loaded and the number of subject file paths found, and then
-begins the search. It progressively reports the number of sketches
-searched in blocks of 10000, and outputs matches to a CSV File.
+The branchwater command line interface provides flexible commands to search
+collections of FracMinHash sketches using either multithreaded search or
+single-threaded disk-based search. Each search command requires input of one or
+more 'query' sketches and a set of 'subject' sketches (sketch database).
+If on-disk search is desired, the 'subject' sketches must first be indexed
+into a RocksDB database via the branchwater index command. Each command
+provides options for specifying the k-mer size, scaled value, and the
+similarity or match threshold for reporting matches.
 
-We typically run branchwater in a snakemake workflow, which manages
-environment variables and input/output files.
+Building the on-disk index can represent a significant upfront time. Once built,
+the on-disk search is extremely memory-efficient and thus excels for extremely
+large collections of sketches. The speed of this search can be limited by the disk I/O speed,
+but the impact is minimal compared with loading the sketches into memory.
+In contrast, the multithreaded search approach is run directly on the sketch files, allowing
+for rapid searches without the need for prior indexing. The performance of
+this search is instead limited by the available RAM and the number of CPU cores available,
+as it processes sketches in parallel using Rust's rayon library.
+
+All search commands report the number of sketches loaded as queries and subjects, and
+report results to a CSV file. We typically run branchwater in a snakemake workflow,
+which manages environment variables and input/output files.
+
+### Sketching the Sequence Read Archive
+
+We determined the accessions of all publicly available shotgun
+metagenomic via the query string `"METAGENOMIC"[Source] NOT
+amplicon[All Fields]` at the NCBI Sequence Read Archive Web site,
+https://www.ncbi.nlm.nih.gov/sra.  We then downloaded all runs for all
+accessions and streamed them into `sourmash sketch dna` with
+parameters `-p k=21,31,51,scaled=1000,abund`. The output sourmash
+signature files were saved as individual gzipped JSON files -
+one file for each input data set, each containing 3 sketches.
+
+For fast, low-memory search, these sketches were then used to build
+an on-disk index using a k-mer size of 21 (Aug 2023). The database
+was subsequently updated with new sketches (Apr 2024?).
+
+<!-- NTP: can we add resource utilization for building initial db and for updating? -->
+
+### Implementation of a search server for SRA metagenomes
+
+The SRA metagenome database represents a specific challenge: building the index
+is extremely time-consuming and requires a large amount of disk space, and the final
+index is very large. To address this, we implemented a search server that
+allows users to query the SRA metagenome database without needing to download or
+index the entire database themselves. The server is implemented in Rust and
+uses the branchwater library to perform searches against the SRA metagenome index.
+The server provides a REST API that allows users to submit queries and receive results
+in JSON format. The server is designed to be scalable and can handle multiple concurrent
+requests. It uses the RocksDB index to quickly retrieve matching sketches and perform
+containment calculations.
+
+To use the server, users can send a POST request to the `/search` endpoint with a JSON
+payload containing the query sketch. The server will then return a JSON response with
+the matching dataset identifiers and their containment values.
+
+Summary information about the index can be retrieved using the `/stats` endpoint,
+which returns the k-mer size, scaled value, threshold, and total number of datasets
+in the current index (JSON). The full list of accessions indexed by the branchwater
+server can be retrieved using the `/accessions` endpoint, which returns a list of all
+accessions currently indexed.
+
+A web search interface is also available at branchwater.jgi.doe.gov, which
+allows users to submit single queries in FASTA format and view results in a
+user-friendly format (CITE). The results include rich graphics and a dynamic table
+with links to the original SRA metadata, allowing users to explore the matched datasets
+further.

--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -10,12 +10,14 @@
 
 ### Implementation of multithreaded search
 
-<!-- CTB: rename program to branchwater? -->
-
-<!-- NTP: modify to better describe all options for multithreaded search? -->
+<!-- NTP: Change "program" to "plugin"? Or how best to describe? -->
 
 The branchwater program is built in Rust on top of the sourmash
-library for loading and comparing sketches. It implements the
+library for loading and comparing sketches. It implements a
+number of multithreaded search strategies for collections of
+FracMinHash sketches.
+
+For searching collections of metagenomes, it implements the
 following steps: <!-- CTB figure? -->
 
 1. Loads the collection of query sketches into memory.
@@ -38,9 +40,9 @@ storing them all in memory. The approach also takes advantage of the
 effective immutability of queries, which can be shared without
 data races by multiple processing threads.
 
-### Implementation of an on-disk index
+### Implementation of on-disk indexing and search
 
-branchwater implements a new index using RocksDB, a high-performance embedded key-value store. This 'inverted' index maps hashed k-mers to the sketches in which they are found. Each ‘key’ in the index is a hashed k-mer stored using little-endian encoding, while each ‘value’ is the list of dataset identifiers that contain this k-mer. This list is stored as a roaring bitmap to enable fast set operations and random access into the list. The index also stores additional metadata per dataset. In particular, this metadata can provide linkages to the FracMinHash sketches from each dataset so they can be loaded for detailed comparison and reporting if needed.
+The sourmash Rust library now implements a new index using RocksDB, a high-performance embedded key-value store. This 'inverted' index maps hashed k-mers to the sketches in which they are found. Each ‘key’ in the index is a hashed k-mer stored using little-endian encoding, while each ‘value’ is the list of dataset identifiers that contain this k-mer. This list is stored as a roaring bitmap to enable fast set operations and random access into the list. The index also stores additional metadata per dataset. In particular, this metadata can provide linkages to the FracMinHash sketches from each dataset so they can be loaded for detailed comparison and reporting if needed.
 
 **Index Construction** The index is constructed by iterating through batches of FracMinHash sketches in parallel and storing each hashed k-mer with its associated dataset ID. If a k-mer occurs in multiple sketches, the corresponding dataset list is updated to include all associated dataset IDs. Values are stored in a compact binary format to reduce storage overhead and improve retrieval speed. Progress is tracked to ensure proper construction and facilitate restart and continuation of the indexing process. After construction of an initial index, updating with new sketches can be done incrementally.
 
@@ -49,6 +51,8 @@ branchwater implements a new index using RocksDB, a high-performance embedded ke
 **Querying the Index** To query the index, branchwater performs batch lookups of the hashed query k-mers in the RocksDB index to retrieve the datasets associated with each hash. These results are then aggregated to determine the number of hashed k-mers found per candidate dataset, i.e. the intersection of k-mers found in the query and each dataset. We can then use the query sketch information to estimate the containment of the query in each dataset (intersection_size/query_size). This approach enables sublinear search time with respect to the total number of k-mers in the database, supporting efficient large-scale sequence comparisons and search across petabyte-scale collections. Other reporting is feasible, but requires loading the FracMinHash sketch associated with each dataset.
 
 ### Executing branchwater at the command line
+
+ <!-- NTP: discuss running py sourmash with RocksDB? -->
 
 The branchwater command line interface provides flexible commands to search
 collections of FracMinHash sketches using either multithreaded search or
@@ -112,7 +116,7 @@ in the current index (JSON). The full list of accessions indexed by the branchwa
 server can be retrieved using the `/accessions` endpoint, which returns a list of all
 accessions currently indexed.
 
-A web search interface is also available at branchwater.jgi.doe.gov, which
+A web search interface is also available at [branchwater.jgi.doe.gov](https://branchwater.jgi.doe.gov), which
 allows users to submit single queries in FASTA format and view results in a
 user-friendly format (CITE). The results include rich graphics and a dynamic table
 with links to the original SRA metadata, allowing users to explore the matched datasets

--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -17,8 +17,8 @@ library for loading and comparing sketches. It implements a
 number of multithreaded search strategies for collections of
 FracMinHash sketches.
 
-For searching collections of metagenomes, it implements the
-following steps: <!-- CTB figure? -->
+For searching collections of metagenomes, the `manysearch` command
+implements the following steps: <!-- CTB figure? -->
 
 1. Loads the collection of query sketches into memory.
 2. Loads references to the collection of subject sketches to search.

--- a/content/05.results.md
+++ b/content/05.results.md
@@ -1,5 +1,48 @@
 ## Results {.page_break_before}
 
+### SRA Metagenome Database
+
+The SRA catalog contains 767,277 metagenome data sets as of
+March 2022, with the largest category annotated as human-associated microbiomes
+(Table @tbl:sra-types). The size of all sketches together is 7.5 TB,
+containing approximately 375 billion hashes per k-mer size and
+representing 375 trillion k-mers <!-- from ZZZ PB of original files CTB -->.
+There are 2.20 billion distinct hashes in this collection, representing
+approximately 2.20 trillion distinct k-mers.
+
+The average FracMinHash sketch file size is 9.7 MB, and the median file
+size is 570kb. The largest 10,000 data sets comprise 30% of the total
+catalog size.
+
+<!-- NTP question: how big is largest sketch? XXX -->
+
+| "Scientific Name" provided by submitter | distinct data sets |
+| --- | --- |
+| human gut metagenome  |   162187 |
+| metagenome              |   57048
+| gut metagenome           | 47244
+| human metagenome         | 36438
+| soil metagenome          | 35323
+| mouse gut metagenome     | 26482
+| human skin metagenome    | 25700
+| Homo sapiens             | 21020
+| marine metagenome        |14400
+| human oral metagenome    |  14235
+
+Table: The 10 largest categories of metagenome data set types in the Sequence
+Read Archive, as of March 2022. {#tbl:sra-types}
+
+
+### Indexing SRA Metagenomes for on-disk search (currently: Aug 2023)
+
+As a RocksDB index, the 2.2 billion FracMinHash hashes require 16.4 Gb of storage,
+while the dataset lists require 1.03 Tb. The maximum list length was 514k, meaning
+that at least one hash was found in over half a million metagenomes. The median list
+length was 65, showing that most of the hashes are found in relatively few metagenomes.
+
+As of June 2025, branchwater indexes 1,161,119 SRA metagenome data sets at a k-mer size
+of 21 with a scaled factor of 1000.
+
 ### Example branchwater search results
 
 <!-- CTB redo with different query -->


### PR DESCRIPTION
## Initial methods updates for 2025:

- Add RocksDB index, search method, SRA index description
- Update branchwater cli description to reflect plugin search utilities and specifically reference `manysearch`.



## Notes
We've done a lot since this ms! Some scoping thoughts:
- Since the focus here is large-scale search in metagenomes, I wasn't going to add discussion of gather style searches. If desired, we could focus on `fastmultigather`, since it can be used to break down the full list of results from `manysearch`/branchwater web query against either a full microbial database or a set of specific genomes and uses both multithreading and rocksdb approaches. Also `gather`/`fastgather` improvements may be added to the `gather` paper?
- Since the focus is mostly on **search**, I was also going to leave discussion of `multisearch`/`pairwise` and/or `cluster` for another paper
